### PR TITLE
feat(scan): add summary statistics and visual improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/sinkers/miner-cli
 
-go 1.23
+go 1.22.0
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/gosnmp/gosnmp v1.42.1
 	github.com/spf13/cobra v1.8.0
 	github.com/x1unix/go-cgminer-api v1.1.1
 	google.golang.org/grpc v1.56.3
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/gosnmp/gosnmp v1.42.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
@@ -7,8 +9,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/gosnmp/gosnmp v1.42.1 h1:MEJxhpC5v1coL3tFRix08PYmky9nyb1TLRRgJAmXm8A=
 github.com/gosnmp/gosnmp v1.42.1/go.mod h1:CxVS6bXqmWZlafUj9pZUnQX5e4fAltqPcijxWpCitDo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -20,11 +22,15 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/x1unix/go-cgminer-api v1.1.1 h1:/9Oj70/G4Qv3CHXm7pam4NHZumeZL+9I0JyWALrR9K4=
 github.com/x1unix/go-cgminer-api v1.1.1/go.mod h1:P71u0EW9NmEtzKigjPsbGdc1Pc1UY7aIjstcqbCuVSY=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
@@ -45,4 +51,5 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"sort"
@@ -394,17 +395,104 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		return ipToInt(results[i].IP) < ipToInt(results[j].IP)
 	})
 
-	// Count active miners
+	// Count active miners and collect statistics
 	activeCount := 0
+	var temperatures []float64
+	var powerLevels []float64
+	var hashrates []float64
+
 	for _, result := range results {
 		if result.Error == "" {
 			activeCount++
+
+			// Extract data for statistics
+			if result.Response != nil {
+				if jsonBytes, err := json.Marshal(result.Response); err == nil {
+					var respMap map[string]interface{}
+					if err := json.Unmarshal(jsonBytes, &respMap); err == nil {
+						// Collect chip temperature
+						if val, ok := respMap["chip_temp_c"]; ok {
+							if temp := toFloat64(val); temp > 0 && temp <= 200 {
+								temperatures = append(temperatures, temp)
+							}
+						} else if t, ok := extractTempFromSummary(respMap); ok && t > 0 && t <= 200 {
+							temperatures = append(temperatures, t)
+						}
+
+						// Collect power consumption (in watts)
+						if val, ok := respMap["power_w"]; ok {
+							if power := toFloat64(val); power > 0 {
+								powerLevels = append(powerLevels, power)
+							}
+						}
+
+						// Collect hashrate (convert to GH/s)
+						if val, ok := respMap["MHS 5s"]; ok {
+							if mhs := toFloat64(val); mhs > 0 {
+								hashrates = append(hashrates, mhs/1000.0)
+							}
+						} else if val, ok := respMap["MHS av"]; ok {
+							if mhs := toFloat64(val); mhs > 0 {
+								hashrates = append(hashrates, mhs/1000.0)
+							}
+						} else if val, ok := respMap["GHS 5s"]; ok {
+							if ghs := toFloat64(val); ghs > 0 {
+								hashrates = append(hashrates, ghs)
+							}
+						} else if val, ok := respMap["GHS av"]; ok {
+							if ghs := toFloat64(val); ghs > 0 {
+								hashrates = append(hashrates, ghs)
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 
 	fmt.Printf("\nActive Miners Found: %d out of %d scanned\n", activeCount, len(results))
 	if activeCount == 0 {
 		return nil
+	}
+
+	// Display summary statistics
+	fmt.Println(strings.Repeat("=", 80))
+	fmt.Println("SUMMARY STATISTICS")
+	fmt.Println(strings.Repeat("-", 80))
+
+	// Temperature statistics
+	if len(temperatures) > 0 {
+		tempStats := calculateStats(temperatures)
+		fmt.Printf("Chip Temperature (°C):\n")
+		fmt.Printf("  Average: %.1f  |  Min: %.1f  |  Max: %.1f  |  Std Dev: %.1f\n",
+			tempStats.avg, tempStats.min, tempStats.max, tempStats.stdDev)
+		fmt.Printf("  Miners reporting: %d/%d\n", len(temperatures), activeCount)
+	} else {
+		fmt.Printf("Chip Temperature: No data available\n")
+	}
+
+	// Power statistics
+	if len(powerLevels) > 0 {
+		powerStats := calculateStats(powerLevels)
+		fmt.Printf("Power Consumption (kW):\n")
+		fmt.Printf("  Average: %.2f  |  Min: %.2f  |  Max: %.2f  |  Std Dev: %.2f\n",
+			powerStats.avg/1000.0, powerStats.min/1000.0, powerStats.max/1000.0, powerStats.stdDev/1000.0)
+		fmt.Printf("  Miners reporting: %d/%d  |  Total: %.2f kW\n",
+			len(powerLevels), activeCount, powerStats.sum/1000.0)
+	} else {
+		fmt.Printf("Power Consumption: No data available\n")
+	}
+
+	// Hashrate statistics
+	if len(hashrates) > 0 {
+		hashStats := calculateStats(hashrates)
+		fmt.Printf("Hashrate (GH/s):\n")
+		fmt.Printf("  Average: %.2f  |  Min: %.2f  |  Max: %.2f  |  Std Dev: %.2f\n",
+			hashStats.avg, hashStats.min, hashStats.max, hashStats.stdDev)
+		fmt.Printf("  Miners reporting: %d/%d  |  Total: %.2f GH/s\n",
+			len(hashrates), activeCount, hashStats.sum)
+	} else {
+		fmt.Printf("Hashrate: No data available\n")
 	}
 
 	fmt.Println(strings.Repeat("=", 80))
@@ -635,4 +723,54 @@ func extractTempFromSummary(resp map[string]interface{}) (float64, bool) {
 		}
 	}
 	return maxT, found
+}
+
+// stats holds statistical calculations
+type stats struct {
+	avg    float64
+	min    float64
+	max    float64
+	stdDev float64
+	sum    float64
+}
+
+// calculateStats computes statistics for a slice of float64 values
+func calculateStats(values []float64) stats {
+	if len(values) == 0 {
+		return stats{}
+	}
+
+	// Calculate sum, min, max
+	sum := 0.0
+	min := values[0]
+	max := values[0]
+	for _, v := range values {
+		sum += v
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+
+	// Calculate average
+	avg := sum / float64(len(values))
+
+	// Calculate standard deviation
+	variance := 0.0
+	for _, v := range values {
+		diff := v - avg
+		variance += diff * diff
+	}
+	variance /= float64(len(values))
+	stdDev := math.Sqrt(variance)
+
+	return stats{
+		avg:    avg,
+		min:    min,
+		max:    max,
+		stdDev: stdDev,
+		sum:    sum,
+	}
 }

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -466,7 +466,7 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 	}
 
 	// Header with icons
-	fmt.Printf("\n%s %s %s %s %s\n",
+	fmt.Printf("\n%s %s %s %s %s %s\n",
 		boldGreen("⛏️  MINER SCAN RESULTS"),
 		white("│"),
 		cyan("🔍 Scanned:"), boldCyan(fmt.Sprintf("%d", len(results))),

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -389,36 +389,21 @@ type ScanFormatter struct {
 	Verbose bool
 }
 
-func (f *ScanFormatter) Format(results []client.Result) error {
-	// Color definitions - define all colors at the start
-	green := color.New(color.FgGreen).SprintFunc()
-	red := color.New(color.FgRed).SprintFunc()
-	yellow := color.New(color.FgYellow).SprintFunc()
-	cyan := color.New(color.FgCyan).SprintFunc()
-	magenta := color.New(color.FgMagenta).SprintFunc()
-	blue := color.New(color.FgBlue).SprintFunc()
-	white := color.New(color.FgWhite).SprintFunc()
-	bold := color.New(color.Bold).SprintFunc()
-	boldGreen := color.New(color.FgGreen, color.Bold).SprintFunc()
-	boldYellow := color.New(color.FgYellow, color.Bold).SprintFunc()
-	boldCyan := color.New(color.FgCyan, color.Bold).SprintFunc()
-	boldMagenta := color.New(color.FgMagenta, color.Bold).SprintFunc()
-	boldRed := color.New(color.FgRed, color.Bold).SprintFunc()
+// scanStats holds collected statistics from scan results
+type scanStats struct {
+	activeCount  int
+	temperatures []float64
+	powerLevels  []float64
+	hashrates    []float64
+}
 
-	// Sort results by IP
-	sort.Slice(results, func(i, j int) bool {
-		return ipToInt(results[i].IP) < ipToInt(results[j].IP)
-	})
-
-	// Count active miners and collect statistics
-	activeCount := 0
-	var temperatures []float64
-	var powerLevels []float64
-	var hashrates []float64
+// collectScanStats gathers statistics from scan results
+func (f *ScanFormatter) collectScanStats(results []client.Result) scanStats {
+	var stats scanStats
 
 	for _, result := range results {
 		if result.Error == "" {
-			activeCount++
+			stats.activeCount++
 
 			// Extract data for statistics
 			if result.Response != nil {
@@ -428,35 +413,35 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 						// Collect chip temperature
 						if val, ok := respMap["chip_temp_c"]; ok {
 							if temp := toFloat64(val); temp > 0 && temp <= 200 {
-								temperatures = append(temperatures, temp)
+								stats.temperatures = append(stats.temperatures, temp)
 							}
 						} else if t, ok := extractTempFromSummary(respMap); ok && t > 0 && t <= 200 {
-							temperatures = append(temperatures, t)
+							stats.temperatures = append(stats.temperatures, t)
 						}
 
 						// Collect power consumption (in watts)
 						if val, ok := respMap["power_w"]; ok {
 							if power := toFloat64(val); power > 0 {
-								powerLevels = append(powerLevels, power)
+								stats.powerLevels = append(stats.powerLevels, power)
 							}
 						}
 
 						// Collect hashrate (convert to GH/s)
 						if val, ok := respMap["MHS 5s"]; ok {
 							if mhs := toFloat64(val); mhs > 0 {
-								hashrates = append(hashrates, mhs/1000.0)
+								stats.hashrates = append(stats.hashrates, mhs/1000.0)
 							}
 						} else if val, ok := respMap["MHS av"]; ok {
 							if mhs := toFloat64(val); mhs > 0 {
-								hashrates = append(hashrates, mhs/1000.0)
+								stats.hashrates = append(stats.hashrates, mhs/1000.0)
 							}
 						} else if val, ok := respMap["GHS 5s"]; ok {
 							if ghs := toFloat64(val); ghs > 0 {
-								hashrates = append(hashrates, ghs)
+								stats.hashrates = append(stats.hashrates, ghs)
 							}
 						} else if val, ok := respMap["GHS av"]; ok {
 							if ghs := toFloat64(val); ghs > 0 {
-								hashrates = append(hashrates, ghs)
+								stats.hashrates = append(stats.hashrates, ghs)
 							}
 						}
 					}
@@ -465,7 +450,11 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		}
 	}
 
-	// Header with icons
+	return stats
+}
+
+// printScanHeader prints the scan results header
+func (f *ScanFormatter) printScanHeader(results []client.Result, activeCount int, boldGreen, white, cyan, boldCyan, green, red, boldRed func(a ...interface{}) string) {
 	fmt.Printf("\n%s %s %s %s %s %s\n",
 		boldGreen("⛏️  MINER SCAN RESULTS"),
 		white("│"),
@@ -474,17 +463,31 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 
 	if activeCount == 0 {
 		fmt.Printf("\n%s %s\n", red("❌"), boldRed("No active miners found"))
-		return nil
 	}
+}
 
-	// Display summary statistics with colors and icons
+// printSummaryStats prints the summary statistics section
+func (f *ScanFormatter) printSummaryStats(stats scanStats, green, red, yellow, cyan, magenta, white, bold, boldCyan, boldYellow, boldMagenta func(a ...interface{}) string) {
 	fmt.Println(cyan(strings.Repeat("═", 80)))
 	fmt.Printf("%s %s\n", boldCyan("📊"), bold("SUMMARY STATISTICS"))
 	fmt.Println(cyan(strings.Repeat("─", 80)))
 
-	// Temperature statistics with thermometer icon
-	if len(temperatures) > 0 {
-		tempStats := calculateStats(temperatures)
+	// Temperature statistics
+	f.printTemperatureStats(stats, green, red, yellow, cyan, white, bold, boldCyan)
+	fmt.Println()
+
+	// Power statistics
+	f.printPowerStats(stats, green, yellow, cyan, white, bold, boldCyan, boldYellow)
+	fmt.Println()
+
+	// Hashrate statistics
+	f.printHashrateStats(stats, cyan, magenta, white, bold, boldCyan, boldMagenta, yellow)
+}
+
+// printTemperatureStats prints temperature statistics
+func (f *ScanFormatter) printTemperatureStats(stats scanStats, green, red, yellow, cyan, white, bold, boldCyan func(a ...interface{}) string) {
+	if len(stats.temperatures) > 0 {
+		tempStats := calculateStats(stats.temperatures)
 		tempColor := green
 		tempIcon := "🌡️"
 		if tempStats.avg > 75 {
@@ -506,16 +509,16 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 			white("σ Std Dev:"), cyan(fmt.Sprintf("%.1f", tempStats.stdDev)))
 		fmt.Printf("  %s %s\n",
 			white("📡 Reporting:"),
-			boldCyan(fmt.Sprintf("%d/%d miners", len(temperatures), activeCount)))
+			boldCyan(fmt.Sprintf("%d/%d miners", len(stats.temperatures), stats.activeCount)))
 	} else {
 		fmt.Printf("%s %s %s\n", "🌡️", bold("Chip Temperature:"), yellow("No data available"))
 	}
+}
 
-	fmt.Println()
-
-	// Power statistics with lightning icon
-	if len(powerLevels) > 0 {
-		powerStats := calculateStats(powerLevels)
+// printPowerStats prints power consumption statistics
+func (f *ScanFormatter) printPowerStats(stats scanStats, green, yellow, cyan, white, bold, boldCyan, boldYellow func(a ...interface{}) string) {
+	if len(stats.powerLevels) > 0 {
+		powerStats := calculateStats(stats.powerLevels)
 		fmt.Printf("%s %s\n", "⚡", bold("Power Consumption (kW):"))
 		fmt.Printf("  %s %s  %s  %s %s  %s  %s %s  %s  %s %s\n",
 			white("📈 Average:"), yellow(fmt.Sprintf("%.2f", powerStats.avg/1000.0)),
@@ -527,20 +530,19 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 			white("σ Std Dev:"), cyan(fmt.Sprintf("%.2f", powerStats.stdDev/1000.0)))
 		fmt.Printf("  %s %s  %s  %s %s\n",
 			white("📡 Reporting:"),
-			boldCyan(fmt.Sprintf("%d/%d miners", len(powerLevels), activeCount)),
+			boldCyan(fmt.Sprintf("%d/%d miners", len(stats.powerLevels), stats.activeCount)),
 			white("│"),
 			white("⚡ Total:"),
 			boldYellow(fmt.Sprintf("%.2f kW", powerStats.sum/1000.0)))
 	} else {
 		fmt.Printf("%s %s %s\n", "⚡", bold("Power Consumption:"), yellow("No data available"))
 	}
+}
 
-	fmt.Println()
-
-	// Hashrate statistics with pickaxe icon
-	if len(hashrates) > 0 {
-		hashStats := calculateStats(hashrates)
-		// Format total hashrate nicely (TH/s if > 1000 GH/s)
+// printHashrateStats prints hashrate statistics
+func (f *ScanFormatter) printHashrateStats(stats scanStats, cyan, magenta, white, bold, boldCyan, boldMagenta, yellow func(a ...interface{}) string) {
+	if len(stats.hashrates) > 0 {
+		hashStats := calculateStats(stats.hashrates)
 		totalHashStr := fmt.Sprintf("%.2f GH/s", hashStats.sum)
 		if hashStats.sum > 1000 {
 			totalHashStr = fmt.Sprintf("%.2f TH/s", hashStats.sum/1000.0)
@@ -557,13 +559,48 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 			white("σ Std Dev:"), cyan(fmt.Sprintf("%.2f", hashStats.stdDev)))
 		fmt.Printf("  %s %s  %s  %s %s\n",
 			white("📡 Reporting:"),
-			boldCyan(fmt.Sprintf("%d/%d miners", len(hashrates), activeCount)),
+			boldCyan(fmt.Sprintf("%d/%d miners", len(stats.hashrates), stats.activeCount)),
 			white("│"),
 			white("💰 Total:"),
 			boldMagenta(totalHashStr))
 	} else {
 		fmt.Printf("%s %s %s\n", "⛏️", bold("Hashrate:"), yellow("No data available"))
 	}
+}
+
+func (f *ScanFormatter) Format(results []client.Result) error {
+	// Color definitions - define all colors at the start
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	cyan := color.New(color.FgCyan).SprintFunc()
+	magenta := color.New(color.FgMagenta).SprintFunc()
+	blue := color.New(color.FgBlue).SprintFunc()
+	white := color.New(color.FgWhite).SprintFunc()
+	bold := color.New(color.Bold).SprintFunc()
+	boldGreen := color.New(color.FgGreen, color.Bold).SprintFunc()
+	boldYellow := color.New(color.FgYellow, color.Bold).SprintFunc()
+	boldCyan := color.New(color.FgCyan, color.Bold).SprintFunc()
+	boldMagenta := color.New(color.FgMagenta, color.Bold).SprintFunc()
+	boldRed := color.New(color.FgRed, color.Bold).SprintFunc()
+
+	// Sort results by IP
+	sort.Slice(results, func(i, j int) bool {
+		return ipToInt(results[i].IP) < ipToInt(results[j].IP)
+	})
+
+	// Collect statistics
+	stats := f.collectScanStats(results)
+
+	// Print header
+	f.printScanHeader(results, stats.activeCount, boldGreen, white, cyan, boldCyan, green, red, boldRed)
+
+	if stats.activeCount == 0 {
+		return nil
+	}
+
+	// Display summary statistics
+	f.printSummaryStats(stats, green, red, yellow, cyan, magenta, white, bold, boldCyan, boldYellow, boldMagenta)
 
 	fmt.Println(cyan(strings.Repeat("═", 80)))
 
@@ -833,17 +870,17 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 
 	// Print summary footer with colors and icons
 	fmt.Println(cyan(strings.Repeat("═", 80)))
-	if f.Verbose && activeCount < len(results) {
+	if f.Verbose && stats.activeCount < len(results) {
 		fmt.Printf("%s %s %s  %s  %s %s  %s  %s %s\n",
 			white("📊"),
 			white("Total:"),
 			boldCyan(fmt.Sprintf("%d", len(results))),
 			white("│"),
 			green("✅ Active:"),
-			boldGreen(fmt.Sprintf("%d", activeCount)),
+			boldGreen(fmt.Sprintf("%d", stats.activeCount)),
 			white("│"),
 			red("❌ Offline:"),
-			boldRed(fmt.Sprintf("%d", len(results)-activeCount)))
+			boldRed(fmt.Sprintf("%d", len(results)-stats.activeCount)))
 	}
 	fmt.Printf("\n%s %s\n", green("✨"), bold("Scan completed successfully!"))
 

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -390,6 +390,21 @@ type ScanFormatter struct {
 }
 
 func (f *ScanFormatter) Format(results []client.Result) error {
+	// Color definitions - define all colors at the start
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	cyan := color.New(color.FgCyan).SprintFunc()
+	magenta := color.New(color.FgMagenta).SprintFunc()
+	blue := color.New(color.FgBlue).SprintFunc()
+	white := color.New(color.FgWhite).SprintFunc()
+	bold := color.New(color.Bold).SprintFunc()
+	boldGreen := color.New(color.FgGreen, color.Bold).SprintFunc()
+	boldYellow := color.New(color.FgYellow, color.Bold).SprintFunc()
+	boldCyan := color.New(color.FgCyan, color.Bold).SprintFunc()
+	boldMagenta := color.New(color.FgMagenta, color.Bold).SprintFunc()
+	boldRed := color.New(color.FgRed, color.Bold).SprintFunc()
+
 	// Sort results by IP
 	sort.Slice(results, func(i, j int) bool {
 		return ipToInt(results[i].IP) < ipToInt(results[j].IP)
@@ -450,52 +465,107 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		}
 	}
 
-	fmt.Printf("\nActive Miners Found: %d out of %d scanned\n", activeCount, len(results))
+	// Header with icons
+	fmt.Printf("\n%s %s %s %s %s\n",
+		boldGreen("⛏️  MINER SCAN RESULTS"),
+		white("│"),
+		cyan("🔍 Scanned:"), boldCyan(fmt.Sprintf("%d", len(results))),
+		green("✓ Active:"), boldGreen(fmt.Sprintf("%d", activeCount)))
+
 	if activeCount == 0 {
+		fmt.Printf("\n%s %s\n", red("❌"), boldRed("No active miners found"))
 		return nil
 	}
 
-	// Display summary statistics
-	fmt.Println(strings.Repeat("=", 80))
-	fmt.Println("SUMMARY STATISTICS")
-	fmt.Println(strings.Repeat("-", 80))
+	// Display summary statistics with colors and icons
+	fmt.Println(cyan(strings.Repeat("═", 80)))
+	fmt.Printf("%s %s\n", boldCyan("📊"), bold("SUMMARY STATISTICS"))
+	fmt.Println(cyan(strings.Repeat("─", 80)))
 
-	// Temperature statistics
+	// Temperature statistics with thermometer icon
 	if len(temperatures) > 0 {
 		tempStats := calculateStats(temperatures)
-		fmt.Printf("Chip Temperature (°C):\n")
-		fmt.Printf("  Average: %.1f  |  Min: %.1f  |  Max: %.1f  |  Std Dev: %.1f\n",
-			tempStats.avg, tempStats.min, tempStats.max, tempStats.stdDev)
-		fmt.Printf("  Miners reporting: %d/%d\n", len(temperatures), activeCount)
+		tempColor := green
+		tempIcon := "🌡️"
+		if tempStats.avg > 75 {
+			tempColor = red
+			tempIcon = "🔥"
+		} else if tempStats.avg > 65 {
+			tempColor = yellow
+			tempIcon = "⚠️"
+		}
+
+		fmt.Printf("%s %s\n", tempIcon, bold("Chip Temperature (°C):"))
+		fmt.Printf("  %s %s  %s  %s %s  %s  %s %s  %s  %s %s\n",
+			white("📈 Average:"), tempColor(fmt.Sprintf("%.1f", tempStats.avg)),
+			white("│"),
+			white("📉 Min:"), green(fmt.Sprintf("%.1f", tempStats.min)),
+			white("│"),
+			white("📊 Max:"), tempColor(fmt.Sprintf("%.1f", tempStats.max)),
+			white("│"),
+			white("σ Std Dev:"), cyan(fmt.Sprintf("%.1f", tempStats.stdDev)))
+		fmt.Printf("  %s %s\n",
+			white("📡 Reporting:"),
+			boldCyan(fmt.Sprintf("%d/%d miners", len(temperatures), activeCount)))
 	} else {
-		fmt.Printf("Chip Temperature: No data available\n")
+		fmt.Printf("%s %s %s\n", "🌡️", bold("Chip Temperature:"), yellow("No data available"))
 	}
 
-	// Power statistics
+	fmt.Println()
+
+	// Power statistics with lightning icon
 	if len(powerLevels) > 0 {
 		powerStats := calculateStats(powerLevels)
-		fmt.Printf("Power Consumption (kW):\n")
-		fmt.Printf("  Average: %.2f  |  Min: %.2f  |  Max: %.2f  |  Std Dev: %.2f\n",
-			powerStats.avg/1000.0, powerStats.min/1000.0, powerStats.max/1000.0, powerStats.stdDev/1000.0)
-		fmt.Printf("  Miners reporting: %d/%d  |  Total: %.2f kW\n",
-			len(powerLevels), activeCount, powerStats.sum/1000.0)
+		fmt.Printf("%s %s\n", "⚡", bold("Power Consumption (kW):"))
+		fmt.Printf("  %s %s  %s  %s %s  %s  %s %s  %s  %s %s\n",
+			white("📈 Average:"), yellow(fmt.Sprintf("%.2f", powerStats.avg/1000.0)),
+			white("│"),
+			white("📉 Min:"), green(fmt.Sprintf("%.2f", powerStats.min/1000.0)),
+			white("│"),
+			white("📊 Max:"), yellow(fmt.Sprintf("%.2f", powerStats.max/1000.0)),
+			white("│"),
+			white("σ Std Dev:"), cyan(fmt.Sprintf("%.2f", powerStats.stdDev/1000.0)))
+		fmt.Printf("  %s %s  %s  %s %s\n",
+			white("📡 Reporting:"),
+			boldCyan(fmt.Sprintf("%d/%d miners", len(powerLevels), activeCount)),
+			white("│"),
+			white("⚡ Total:"),
+			boldYellow(fmt.Sprintf("%.2f kW", powerStats.sum/1000.0)))
 	} else {
-		fmt.Printf("Power Consumption: No data available\n")
+		fmt.Printf("%s %s %s\n", "⚡", bold("Power Consumption:"), yellow("No data available"))
 	}
 
-	// Hashrate statistics
+	fmt.Println()
+
+	// Hashrate statistics with pickaxe icon
 	if len(hashrates) > 0 {
 		hashStats := calculateStats(hashrates)
-		fmt.Printf("Hashrate (GH/s):\n")
-		fmt.Printf("  Average: %.2f  |  Min: %.2f  |  Max: %.2f  |  Std Dev: %.2f\n",
-			hashStats.avg, hashStats.min, hashStats.max, hashStats.stdDev)
-		fmt.Printf("  Miners reporting: %d/%d  |  Total: %.2f GH/s\n",
-			len(hashrates), activeCount, hashStats.sum)
+		// Format total hashrate nicely (TH/s if > 1000 GH/s)
+		totalHashStr := fmt.Sprintf("%.2f GH/s", hashStats.sum)
+		if hashStats.sum > 1000 {
+			totalHashStr = fmt.Sprintf("%.2f TH/s", hashStats.sum/1000.0)
+		}
+
+		fmt.Printf("%s %s\n", "⛏️", bold("Hashrate (GH/s):"))
+		fmt.Printf("  %s %s  %s  %s %s  %s  %s %s  %s  %s %s\n",
+			white("📈 Average:"), magenta(fmt.Sprintf("%.2f", hashStats.avg)),
+			white("│"),
+			white("📉 Min:"), cyan(fmt.Sprintf("%.2f", hashStats.min)),
+			white("│"),
+			white("📊 Max:"), magenta(fmt.Sprintf("%.2f", hashStats.max)),
+			white("│"),
+			white("σ Std Dev:"), cyan(fmt.Sprintf("%.2f", hashStats.stdDev)))
+		fmt.Printf("  %s %s  %s  %s %s\n",
+			white("📡 Reporting:"),
+			boldCyan(fmt.Sprintf("%d/%d miners", len(hashrates), activeCount)),
+			white("│"),
+			white("💰 Total:"),
+			boldMagenta(totalHashStr))
 	} else {
-		fmt.Printf("Hashrate: No data available\n")
+		fmt.Printf("%s %s %s\n", "⛏️", bold("Hashrate:"), yellow("No data available"))
 	}
 
-	fmt.Println(strings.Repeat("=", 80))
+	fmt.Println(cyan(strings.Repeat("═", 80)))
 
 	// Create tabwriter
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -516,13 +586,16 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		}
 	}
 
+	// Color for table header
+	headerColor := color.New(color.FgCyan, color.Bold).SprintFunc()
+
 	// Print header (with or without port column)
 	if hasPortData {
-		fmt.Fprintln(w, "IP\tPort\tFirmware\tHashrate (GH/s)\tPower (kW)\tTemp (°C)\tTuning\tAccepted\tRejected\tHW Errors\tUptime")
-		fmt.Fprintln(w, "---\t----\t--------\t--------------\t----------\t---------\t------\t--------\t--------\t---------\t------")
+		fmt.Fprintln(w, headerColor("IP\tPort\tFirmware\tHashrate (GH/s)\tPower (kW)\tTemp (°C)\tTuning\tAccepted\tRejected\tHW Errors\tUptime"))
+		fmt.Fprintln(w, cyan("───\t────\t────────\t──────────────\t──────────\t─────────\t──────\t────────\t────────\t─────────\t──────"))
 	} else {
-		fmt.Fprintln(w, "IP\tFirmware\tHashrate (GH/s)\tPower (kW)\tTemp (°C)\tTuning\tAccepted\tRejected\tHW Errors\tUptime")
-		fmt.Fprintln(w, "---\t--------\t--------------\t----------\t---------\t------\t--------\t--------\t---------\t------")
+		fmt.Fprintln(w, headerColor("IP\tFirmware\tHashrate (GH/s)\tPower (kW)\tTemp (°C)\tTuning\tAccepted\tRejected\tHW Errors\tUptime"))
+		fmt.Fprintln(w, cyan("───\t────────\t──────────────\t──────────\t─────────\t──────\t────────\t────────\t─────────\t──────"))
 	}
 
 	for _, result := range results {
@@ -652,44 +725,127 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 			}
 		}
 
+		// Color the data based on values
+		ipColor := white(result.IP)
+
+		// Color firmware based on type
+		firmwareColor := firmware
+		if strings.Contains(firmware, "Braiins") {
+			firmwareColor = blue(firmware)
+		} else if firmware == "Stock" {
+			firmwareColor = white(firmware)
+		}
+
+		// Color hashrate
+		hashrateColor := hashrate
+		if hashrate != "-" {
+			hr := toFloat64(strings.TrimSuffix(hashrate, " GH/s"))
+			if hr > 130000 {
+				hashrateColor = boldMagenta(hashrate)
+			} else if hr > 125000 {
+				hashrateColor = magenta(hashrate)
+			} else {
+				hashrateColor = cyan(hashrate)
+			}
+		}
+
+		// Color power
+		powerColor := powerKW
+		if powerKW != "-" {
+			pw := toFloat64(strings.TrimSuffix(powerKW, " kW"))
+			if pw > 4.2 {
+				powerColor = red(powerKW)
+			} else {
+				powerColor = yellow(powerKW)
+			}
+		}
+
+		// Color temperature based on value
+		tempColor := chipTemp
+		if chipTemp != "-" {
+			temp := toFloat64(strings.TrimSuffix(chipTemp, "°C"))
+			if temp > 75 {
+				tempColor = boldRed(chipTemp)
+			} else if temp > 65 {
+				tempColor = yellow(chipTemp)
+			} else {
+				tempColor = green(chipTemp)
+			}
+		}
+
+		// Color tuning status
+		tuningColor := tuning
+		if tuning == "STABLE" {
+			tuningColor = green("✓ " + tuning)
+		} else if tuning == "Yes" || tuning == "TUNING" {
+			tuningColor = yellow("⚙ " + tuning)
+		} else if tuning != "-" {
+			tuningColor = cyan(tuning)
+		}
+
+		// Color HW errors
+		hwErrorsColor := hwErrors
+		if hwErrors != "-" {
+			errors := toFloat64(hwErrors)
+			if errors > 100 {
+				hwErrorsColor = boldRed(hwErrors)
+			} else if errors > 0 {
+				hwErrorsColor = yellow(hwErrors)
+			} else {
+				hwErrorsColor = green(hwErrors)
+			}
+		}
+
+		// Color uptime
+		uptimeColor := cyan(uptime)
+
 		if hasPortData {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				result.IP,
-				switchPort,
-				firmware,
-				hashrate,
-				powerKW,
-				chipTemp,
-				tuning,
-				accepted,
-				rejected,
-				hwErrors,
-				uptime,
+				ipColor,
+				white(switchPort),
+				firmwareColor,
+				hashrateColor,
+				powerColor,
+				tempColor,
+				tuningColor,
+				white(accepted),
+				white(rejected),
+				hwErrorsColor,
+				uptimeColor,
 			)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				result.IP,
-				firmware,
-				hashrate,
-				powerKW,
-				chipTemp,
-				tuning,
-				accepted,
-				rejected,
-				hwErrors,
-				uptime,
+				ipColor,
+				firmwareColor,
+				hashrateColor,
+				powerColor,
+				tempColor,
+				tuningColor,
+				white(accepted),
+				white(rejected),
+				hwErrorsColor,
+				uptimeColor,
 			)
 		}
 	}
 
 	w.Flush()
 
-	// Print summary
-	fmt.Println(strings.Repeat("=", 80))
+	// Print summary footer with colors and icons
+	fmt.Println(cyan(strings.Repeat("═", 80)))
 	if f.Verbose && activeCount < len(results) {
-		fmt.Printf("Total: %d hosts scanned, %d active, %d offline\n",
-			len(results), activeCount, len(results)-activeCount)
+		fmt.Printf("%s %s %s  %s  %s %s  %s  %s %s\n",
+			white("📊"),
+			white("Total:"),
+			boldCyan(fmt.Sprintf("%d", len(results))),
+			white("│"),
+			green("✅ Active:"),
+			boldGreen(fmt.Sprintf("%d", activeCount)),
+			white("│"),
+			red("❌ Offline:"),
+			boldRed(fmt.Sprintf("%d", len(results)-activeCount)))
 	}
+	fmt.Printf("\n%s %s\n", green("✨"), bold("Scan completed successfully!"))
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add comprehensive summary statistics (temperature, power, hashrate) with icons and color coding
- Add colors and icons throughout scan output for better visual appeal and data interpretation
- Fix printf format string bug in header output that caused formatting errors

## Changes
- Temperature statistics with color-coded warnings (🌡️ green <65°C, ⚠️ yellow 65-75°C, 🔥 red >75°C)
- Power consumption statistics with total kW tracking (⚡)
- Hashrate statistics with total TH/s display (⛏️)
- All statistics include: average, min, max, standard deviation, and reporting count
- Color-coded table values for quick identification of issues:
  - Temperature: green/yellow/red based on thresholds
  - Power: yellow/red based on consumption
  - Hardware errors: green (0) / yellow (>0) / red (>100)
  - Tuning status: green (STABLE) / yellow (TUNING)
- Fixed formatting bug where header had mismatched printf arguments

## Test plan
- [x] Build succeeds without errors
- [x] Scan command displays header correctly without format errors
- [x] Statistics section formats properly with colors and icons
- [x] Table columns align correctly with color-coded values
- [x] Works with both active and inactive miners