### PR TITLE
feat: add WhatsMiner integration and enhanced scanning capabilities

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -62,7 +62,8 @@
       "Bash(do echo \"=== Testing $ip ===\")",
       "Bash(for ip in 10.45.17.14 10.45.17.15 10.45.17.16 10.45.17.17 10.45.17.18)",
       "Bash(do echo \"=== $ip ===\")",
-      "Bash(go test:*)"
+      "Bash(go test:*)",
+      "Bash(gh pr merge:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -65,7 +65,9 @@
       "Bash(go test:*)",
       "Bash(gh pr merge:*)",
       "Bash(go run:*)",
-      "Bash(./test_whatsminer:*)"
+      "Bash(./test_whatsminer:*)",
+      "Bash(cat:*)",
+      "Bash(pkill -f \"miner-cli scan 10.45.78.0/24\")"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -63,7 +63,9 @@
       "Bash(for ip in 10.45.17.14 10.45.17.15 10.45.17.16 10.45.17.17 10.45.17.18)",
       "Bash(do echo \"=== $ip ===\")",
       "Bash(go test:*)",
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "Bash(go run:*)",
+      "Bash(./test_whatsminer:*)"
     ],
     "deny": [],
     "ask": []

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -338,6 +338,8 @@ func enrichBraiinsMiners(results []client.Result) {
 
 // enrichWhatsMiners tries to get info from WhatsMiner API for miners that didn't respond to CGMiner
 func enrichWhatsMiners(results []client.Result) {
+	// Find IPs that need WhatsMiner detection
+	var ipsToCheck []int
 	for i := range results {
 		// Skip if already has a successful response or is a known Braiins miner
 		if results[i].Error == "" {
@@ -350,66 +352,110 @@ func enrichWhatsMiners(results []client.Result) {
 				}
 			}
 		}
+		ipsToCheck = append(ipsToCheck, i)
+	}
 
-		// Try to detect WhatsMiner on port 4433
-		wmClient := whatsminer.NewClient(results[i].IP, 4433, "super", "super", 2*time.Second)
-		if err := wmClient.Connect(); err != nil {
-			continue // Not a WhatsMiner or unreachable
-		}
+	if len(ipsToCheck) == 0 {
+		return
+	}
 
-		// Get device info to confirm it's a WhatsMiner and extract model
-		deviceInfo, err := wmClient.GetDeviceInfo()
-		if err != nil || !deviceInfo.IsSuccess() {
-			wmClient.Close()
-			continue
-		}
+	// Use concurrency for WhatsMiner detection
+	type wmResult struct {
+		index    int
+		response map[string]interface{}
+		error    string
+	}
 
-		// Extract model from device info
-		model := "WhatsMiner"
-		if msg, err := deviceInfo.GetMsg(); err == nil {
-			if miner, ok := msg["miner"].(map[string]interface{}); ok {
-				if minerType, ok := miner["type"].(string); ok {
-					model = fmt.Sprintf("WhatsMiner %s", minerType)
+	resultsChan := make(chan wmResult, len(ipsToCheck))
+	maxWorkers := 50 // Limit concurrent connections
+	sem := make(chan struct{}, maxWorkers)
+
+	for _, idx := range ipsToCheck {
+		go func(i int) {
+			sem <- struct{}{} // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			ip := results[i].IP
+
+			// Try to detect WhatsMiner on port 4433
+			wmClient := whatsminer.NewClient(ip, 4433, "super", "super", 2*time.Second)
+			if err := wmClient.Connect(); err != nil {
+				resultsChan <- wmResult{index: i}
+				return
+			}
+
+			// Get device info to confirm it's a WhatsMiner and extract model
+			deviceInfo, err := wmClient.GetDeviceInfo()
+			if err != nil || !deviceInfo.IsSuccess() {
+				wmClient.Close()
+				resultsChan <- wmResult{index: i}
+				return
+			}
+
+			// Extract model from device info
+			model := "WhatsMiner"
+			if msg, err := deviceInfo.GetMsg(); err == nil {
+				if miner, ok := msg["miner"].(map[string]interface{}); ok {
+					if minerType, ok := miner["type"].(string); ok {
+						model = fmt.Sprintf("WhatsMiner %s", minerType)
+					}
 				}
 			}
-		}
 
-		// Get miner stats
-		stats, err := wmClient.GetMinerStats()
-		wmClient.Close()
+			// Get miner stats
+			stats, err := wmClient.GetMinerStats()
+			wmClient.Close()
 
-		if err != nil {
-			// Create minimal response even if stats fail
-			results[i].Response = map[string]interface{}{
-				"firmware": model,
-				"MHS 5s":   0,
-				"MHS av":   0,
+			if err != nil {
+				// Create minimal response even if stats fail
+				resultsChan <- wmResult{
+					index: i,
+					response: map[string]interface{}{
+						"firmware": model,
+						"MHS 5s":   0,
+						"MHS av":   0,
+					},
+					error: "",
+				}
+				return
 			}
-			results[i].Error = "" // Clear error since we detected the device
-			continue
-		}
 
-		// Convert TH/s to MH/s for consistency with CGMiner API
-		hashrateMHS := stats.Hashrate * 1000000.0
+			// Convert TH/s to MH/s for consistency with CGMiner API
+			hashrateMHS := stats.Hashrate * 1000000.0
 
-		// Create response in CGMiner format for compatibility
-		results[i].Response = map[string]interface{}{
-			"firmware":        model,
-			"MHS 5s":          hashrateMHS,
-			"MHS av":          hashrateMHS,
-			"power_w":         stats.Power,
-			"chip_temp_c":     stats.Temp,
-			"Accepted":        0, // Not available from WhatsMiner summary
-			"Rejected":        0,
-			"Hardware Errors": 0,
-			"Elapsed":         0,
-			"working":         stats.Working,
-		}
-		results[i].Error = "" // Clear error since we successfully got data
+			// Create response in CGMiner format for compatibility
+			resp := map[string]interface{}{
+				"firmware":        model,
+				"MHS 5s":          hashrateMHS,
+				"MHS av":          hashrateMHS,
+				"power_w":         stats.Power,
+				"chip_temp_c":     stats.Temp,
+				"Accepted":        0, // Not available from WhatsMiner summary
+				"Rejected":        0,
+				"Hardware Errors": 0,
+				"Elapsed":         0,
+				"working":         stats.Working,
+			}
 
-		// Add status based on working field
-		if !stats.Working {
-			results[i].Error = "Disconnected" // Indicate miner is not mining
+			errMsg := ""
+			if !stats.Working {
+				errMsg = "Disconnected" // Indicate miner is not mining
+			}
+
+			resultsChan <- wmResult{
+				index:    i,
+				response: resp,
+				error:    errMsg,
+			}
+		}(idx)
+	}
+
+	// Collect results
+	for range ipsToCheck {
+		result := <-resultsChan
+		if result.response != nil {
+			results[result.index].Response = result.response
+			results[result.index].Error = result.error
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -165,6 +165,7 @@ func init() {
 
 	// Flag to optionally fetch chip temperatures via a second pass
 	scanCmd.Flags().Bool("scan-temps", false, "Fetch chip temperature via device metrics (slower)")
+	scanCmd.Flags().Bool("check-errors", false, "Check WhatsMiner devices for error codes")
 	scanCmd.Flags().StringVar(&switchIP, "switch", "", "Switch IP address for SNMP port lookup (e.g., 10.110.101.6)")
 	scanCmd.Flags().StringVar(&switchCommunity, "community", "public", "SNMP community string for switch")
 	scanCmd.Flags().StringVar(&braiinsUsername, "braiins-user", "root", "Braiins OS username for MAC address retrieval")
@@ -252,7 +253,8 @@ func scanMiners(cmd *cobra.Command, args []string) error {
 	enrichBraiinsMiners(results)
 
 	// Try to get info from WhatsMiner API for devices that didn't respond to CGMiner
-	enrichWhatsMiners(results)
+	checkErrors, _ := cmd.Flags().GetBool("check-errors")
+	enrichWhatsMiners(results, checkErrors)
 
 	// Setup switch port mapping if requested
 	portMap, arpCache := setupSwitchMapping()
@@ -337,7 +339,7 @@ func enrichBraiinsMiners(results []client.Result) {
 }
 
 // enrichWhatsMiners tries to get info from WhatsMiner API for miners that didn't respond to CGMiner
-func enrichWhatsMiners(results []client.Result) {
+func enrichWhatsMiners(results []client.Result, checkErrors bool) {
 	// Find IPs that need WhatsMiner detection
 	var ipsToCheck []int
 	for i := range results {
@@ -402,6 +404,12 @@ func enrichWhatsMiners(results []client.Result) {
 				}
 			}
 
+			// Extract error codes if requested
+			var errorCodes []whatsminer.ErrorCodeInfo
+			if checkErrors {
+				errorCodes = whatsminer.GetErrorCodesFromDeviceInfo(deviceInfo)
+			}
+
 			// Get miner stats
 			stats, err := wmClient.GetMinerStats()
 			wmClient.Close()
@@ -435,6 +443,11 @@ func enrichWhatsMiners(results []client.Result) {
 				"Hardware Errors": 0,
 				"Elapsed":         0,
 				"working":         stats.Working,
+			}
+
+			// Add error codes if they exist
+			if len(errorCodes) > 0 {
+				resp["error_codes"] = errorCodes
 			}
 
 			errMsg := ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,9 @@ var (
 	// Braiins authentication for MAC address retrieval
 	braiinsUsername string
 	braiinsPassword string
+
+	// Display options
+	showMAC bool
 )
 
 const (
@@ -91,6 +94,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&workers, "workers", "w", 255, "Number of concurrent workers")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "color", "Output format (color, json, table)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+	rootCmd.PersistentFlags().BoolVar(&showMAC, "show-mac", false, "Display MAC addresses in output table")
 
 	commands := client.GetAvailableCommands()
 	for _, cmd := range commands {
@@ -217,7 +221,7 @@ func executeCommand(command string) error {
 		formatToUse = "summary"
 	}
 
-	formatter := output.GetFormatter(formatToUse, verbose)
+	formatter := output.GetFormatter(formatToUse, verbose, showMAC)
 	return formatter.Format(results)
 }
 
@@ -289,12 +293,12 @@ func scanMiners(cmd *cobra.Command, args []string) error {
 	}
 
 	if outputFormat == outputFormatJSON {
-		formatter := output.GetFormatter(outputFormat, verbose)
+		formatter := output.GetFormatter(outputFormat, verbose, showMAC)
 		return formatter.Format(filteredResults)
 	}
 
 	// Use the new scan formatter for better output
-	formatter := output.GetFormatter("scan", verbose)
+	formatter := output.GetFormatter("scan", verbose, showMAC)
 	return formatter.Format(filteredResults)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sinkers/miner-cli/internal/iprange"
 	"github.com/sinkers/miner-cli/internal/output"
 	"github.com/sinkers/miner-cli/internal/snmp"
+	"github.com/sinkers/miner-cli/internal/whatsminer"
 	"github.com/spf13/cobra"
 )
 
@@ -250,6 +251,9 @@ func scanMiners(cmd *cobra.Command, args []string) error {
 	// Try to get info from Braiins GraphQL for miners that didn't respond to CGMiner
 	enrichBraiinsMiners(results)
 
+	// Try to get info from WhatsMiner API for devices that didn't respond to CGMiner
+	enrichWhatsMiners(results)
+
 	// Setup switch port mapping if requested
 	portMap, arpCache := setupSwitchMapping()
 
@@ -328,6 +332,79 @@ func enrichBraiinsMiners(results []client.Result) {
 					// Keep the error but it will be treated as "disconnected"
 				}
 			}
+		}
+	}
+}
+
+// enrichWhatsMiners tries to get info from WhatsMiner API for miners that didn't respond to CGMiner
+func enrichWhatsMiners(results []client.Result) {
+	for i := range results {
+		// Skip if already has a successful response or is a known Braiins miner
+		if results[i].Error == "" {
+			continue
+		}
+		if results[i].Response != nil {
+			if fw, ok := results[i].Response.(map[string]interface{})["firmware"]; ok {
+				if fwStr, ok := fw.(string); ok && strings.Contains(fwStr, "Braiins") {
+					continue
+				}
+			}
+		}
+
+		// Try to detect WhatsMiner on port 4433
+		wmClient := whatsminer.NewClient(results[i].IP, 4433, "super", "super", 2*time.Second)
+		if err := wmClient.Connect(); err != nil {
+			continue // Not a WhatsMiner or unreachable
+		}
+
+		// Get device info to confirm it's a WhatsMiner
+		deviceInfo, err := wmClient.GetDeviceInfo()
+		wmClient.Close()
+		if err != nil || !deviceInfo.IsSuccess() {
+			continue
+		}
+
+		// Get miner stats
+		wmClient = whatsminer.NewClient(results[i].IP, 4433, "super", "super", 2*time.Second)
+		if err := wmClient.Connect(); err != nil {
+			continue
+		}
+
+		stats, err := wmClient.GetMinerStats()
+		wmClient.Close()
+
+		if err != nil {
+			// Create minimal response even if stats fail
+			results[i].Response = map[string]interface{}{
+				"firmware": "WhatsMiner",
+				"MHS 5s":   0,
+				"MHS av":   0,
+			}
+			results[i].Error = "" // Clear error since we detected the device
+			continue
+		}
+
+		// Convert TH/s to MH/s for consistency with CGMiner API
+		hashrateMHS := stats.Hashrate * 1000000.0
+
+		// Create response in CGMiner format for compatibility
+		results[i].Response = map[string]interface{}{
+			"firmware":        fmt.Sprintf("WhatsMiner %s", stats.Model),
+			"MHS 5s":          hashrateMHS,
+			"MHS av":          hashrateMHS,
+			"power_w":         stats.Power,
+			"chip_temp_c":     stats.Temp,
+			"Accepted":        0, // Not available from WhatsMiner summary
+			"Rejected":        0,
+			"Hardware Errors": 0,
+			"Elapsed":         0,
+			"working":         stats.Working,
+		}
+		results[i].Error = "" // Clear error since we successfully got data
+
+		// Add status based on working field
+		if !stats.Working {
+			results[i].Error = "Disconnected" // Indicate miner is not mining
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -394,12 +394,19 @@ func enrichWhatsMiners(results []client.Result, checkErrors bool) {
 				return
 			}
 
-			// Extract model from device info
+			// Extract model and MAC address from device info
 			model := "WhatsMiner"
+			macAddress := ""
 			if msg, err := deviceInfo.GetMsg(); err == nil {
 				if miner, ok := msg["miner"].(map[string]interface{}); ok {
 					if minerType, ok := miner["type"].(string); ok {
 						model = fmt.Sprintf("WhatsMiner %s", minerType)
+					}
+				}
+				// Extract MAC address from network section
+				if network, ok := msg["network"].(map[string]interface{}); ok {
+					if mac, ok := network["mac"].(string); ok {
+						macAddress = mac
 					}
 				}
 			}
@@ -443,6 +450,11 @@ func enrichWhatsMiners(results []client.Result, checkErrors bool) {
 				"Hardware Errors": 0,
 				"Elapsed":         0,
 				"working":         stats.Working,
+			}
+
+			// Add MAC address if available
+			if macAddress != "" {
+				resp["mac_address"] = macAddress
 			}
 
 			// Add error codes if they exist

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -401,7 +401,7 @@ func enrichWhatsMiners(results []client.Result, checkErrors bool) {
 			// Extract model and MAC address from device info
 			model := "WhatsMiner"
 			macAddress := ""
-			if msg, err := deviceInfo.GetMsg(); err == nil {
+			if msg, msgErr := deviceInfo.GetMsg(); msgErr == nil {
 				if miner, ok := msg["miner"].(map[string]interface{}); ok {
 					if minerType, ok := miner["type"].(string); ok {
 						model = fmt.Sprintf("WhatsMiner %s", minerType)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -357,26 +357,31 @@ func enrichWhatsMiners(results []client.Result) {
 			continue // Not a WhatsMiner or unreachable
 		}
 
-		// Get device info to confirm it's a WhatsMiner
+		// Get device info to confirm it's a WhatsMiner and extract model
 		deviceInfo, err := wmClient.GetDeviceInfo()
-		wmClient.Close()
 		if err != nil || !deviceInfo.IsSuccess() {
+			wmClient.Close()
 			continue
+		}
+
+		// Extract model from device info
+		model := "WhatsMiner"
+		if msg, err := deviceInfo.GetMsg(); err == nil {
+			if miner, ok := msg["miner"].(map[string]interface{}); ok {
+				if minerType, ok := miner["type"].(string); ok {
+					model = fmt.Sprintf("WhatsMiner %s", minerType)
+				}
+			}
 		}
 
 		// Get miner stats
-		wmClient = whatsminer.NewClient(results[i].IP, 4433, "super", "super", 2*time.Second)
-		if err := wmClient.Connect(); err != nil {
-			continue
-		}
-
 		stats, err := wmClient.GetMinerStats()
 		wmClient.Close()
 
 		if err != nil {
 			// Create minimal response even if stats fail
 			results[i].Response = map[string]interface{}{
-				"firmware": "WhatsMiner",
+				"firmware": model,
 				"MHS 5s":   0,
 				"MHS av":   0,
 			}
@@ -389,7 +394,7 @@ func enrichWhatsMiners(results []client.Result) {
 
 		// Create response in CGMiner format for compatibility
 		results[i].Response = map[string]interface{}{
-			"firmware":        fmt.Sprintf("WhatsMiner %s", stats.Model),
+			"firmware":        model,
 			"MHS 5s":          hashrateMHS,
 			"MHS av":          hashrateMHS,
 			"power_w":         stats.Power,

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/sinkers/miner-cli/internal/client"
@@ -669,6 +670,82 @@ func (f *ScanFormatter) printHashrateStats(stats scanStats, cyan, magenta, white
 	}
 }
 
+// printErrorCodes displays WhatsMiner error codes if any exist
+func (f *ScanFormatter) printErrorCodes(results []client.Result, yellow, red, white, cyan, bold, boldYellow func(a ...interface{}) string) {
+	type minerWithErrors struct {
+		IP         string
+		ErrorCodes []map[string]interface{}
+	}
+
+	var minersWithErrors []minerWithErrors
+
+	// Collect miners that have error codes
+	for _, result := range results {
+		if result.Response != nil {
+			if jsonBytes, err := json.Marshal(result.Response); err == nil {
+				var respMap map[string]interface{}
+				if err := json.Unmarshal(jsonBytes, &respMap); err == nil {
+					if errorCodes, ok := respMap["error_codes"]; ok {
+						if errorCodesArray, ok := errorCodes.([]interface{}); ok && len(errorCodesArray) > 0 {
+							var codes []map[string]interface{}
+							for _, ec := range errorCodesArray {
+								if ecMap, ok := ec.(map[string]interface{}); ok {
+									codes = append(codes, ecMap)
+								}
+							}
+							if len(codes) > 0 {
+								minersWithErrors = append(minersWithErrors, minerWithErrors{
+									IP:         result.IP,
+									ErrorCodes: codes,
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Print error codes section if any exist
+	if len(minersWithErrors) > 0 {
+		fmt.Println()
+		fmt.Println(cyan(strings.Repeat("═", 80)))
+		fmt.Printf("%s %s\n", boldYellow("⚠️  ERROR CODES DETECTED"), yellow(fmt.Sprintf("(%d miner(s) with errors)", len(minersWithErrors))))
+		fmt.Println(cyan(strings.Repeat("─", 80)))
+
+		for _, miner := range minersWithErrors {
+			fmt.Printf("%s %s\n", bold("Miner:"), white(miner.IP))
+			for i, errCode := range miner.ErrorCodes {
+				code := "Unknown"
+				if ec, ok := errCode["error_code"].(string); ok {
+					code = ec
+				}
+				message := ""
+				if msg, ok := errCode["msg"].(string); ok {
+					message = msg
+				}
+				timestamp := ""
+				if ts, ok := errCode["timestamp"].(float64); ok {
+					timestamp = time.Unix(int64(ts), 0).Format("2006-01-02 15:04:05")
+				}
+
+				if message != "" {
+					fmt.Printf("  %s %s %s %s", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code), white(fmt.Sprintf("- %s", message)))
+				} else {
+					fmt.Printf("  %s %s %s", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code))
+				}
+				if timestamp != "" {
+					fmt.Printf(" %s\n", white(fmt.Sprintf("(at %s)", timestamp)))
+				} else {
+					fmt.Println()
+				}
+			}
+			fmt.Println()
+		}
+		fmt.Println(cyan(strings.Repeat("═", 80)))
+	}
+}
+
 func (f *ScanFormatter) Format(results []client.Result) error {
 	// Color definitions - define all colors at the start
 	green := color.New(color.FgGreen).SprintFunc()
@@ -814,6 +891,10 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 			red("❌ Offline:"),
 			boldRed(fmt.Sprintf("%d", len(results)-stats.activeCount)))
 	}
+
+	// Print error codes if any exist
+	f.printErrorCodes(results, yellow, red, white, cyan, bold, boldYellow)
+
 	fmt.Printf("\n%s %s\n", green("✨"), bold("Scan completed successfully!"))
 
 	return nil

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/sinkers/miner-cli/internal/client"
@@ -735,20 +734,11 @@ func (f *ScanFormatter) printErrorCodes(results []client.Result, yellow, red, wh
 				if msg, ok := errCode["msg"].(string); ok {
 					message = msg
 				}
-				timestamp := ""
-				if ts, ok := errCode["timestamp"].(float64); ok {
-					timestamp = time.Unix(int64(ts), 0).Format("2006-01-02 15:04:05")
-				}
 
 				if message != "" {
-					fmt.Printf("  %s %s %s %s", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code), white(fmt.Sprintf("- %s", message)))
+					fmt.Printf("  %s %s %s %s\n", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code), white(fmt.Sprintf("- %s", message)))
 				} else {
-					fmt.Printf("  %s %s %s", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code))
-				}
-				if timestamp != "" {
-					fmt.Printf(" %s\n", white(fmt.Sprintf("(at %s)", timestamp)))
-				} else {
-					fmt.Println()
+					fmt.Printf("  %s %s %s\n", red(fmt.Sprintf("[%d]", i+1)), yellow("Code:"), red(code))
 				}
 			}
 			fmt.Println()

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -674,6 +674,7 @@ func (f *ScanFormatter) printHashrateStats(stats scanStats, cyan, magenta, white
 func (f *ScanFormatter) printErrorCodes(results []client.Result, yellow, red, white, cyan, bold, boldYellow func(a ...interface{}) string) {
 	type minerWithErrors struct {
 		IP         string
+		MAC        string
 		ErrorCodes []map[string]interface{}
 	}
 
@@ -694,8 +695,14 @@ func (f *ScanFormatter) printErrorCodes(results []client.Result, yellow, red, wh
 								}
 							}
 							if len(codes) > 0 {
+								// Extract MAC address if available
+								macAddr := ""
+								if mac, ok := respMap["mac_address"].(string); ok {
+									macAddr = mac
+								}
 								minersWithErrors = append(minersWithErrors, minerWithErrors{
 									IP:         result.IP,
+									MAC:        macAddr,
 									ErrorCodes: codes,
 								})
 							}
@@ -714,7 +721,11 @@ func (f *ScanFormatter) printErrorCodes(results []client.Result, yellow, red, wh
 		fmt.Println(cyan(strings.Repeat("─", 80)))
 
 		for _, miner := range minersWithErrors {
-			fmt.Printf("%s %s\n", bold("Miner:"), white(miner.IP))
+			if miner.MAC != "" {
+				fmt.Printf("%s %s %s %s\n", bold("Miner:"), white(miner.IP), cyan("MAC:"), white(miner.MAC))
+			} else {
+				fmt.Printf("%s %s\n", bold("Miner:"), white(miner.IP))
+			}
 			for i, errCode := range miner.ErrorCodes {
 				code := "Unknown"
 				if ec, ok := errCode["error_code"].(string); ok {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -27,16 +27,16 @@ type Formatter interface {
 	Format(results []client.Result) error
 }
 
-func GetFormatter(format string, verbose bool) Formatter {
+func GetFormatter(format string, verbose bool, showMAC bool) Formatter {
 	switch strings.ToLower(format) {
 	case "json":
 		return &JSONFormatter{Pretty: verbose}
 	case "table":
 		return &TableFormatter{Verbose: verbose}
 	case "summary":
-		return &SummaryTableFormatter{}
+		return &SummaryTableFormatter{ShowMAC: showMAC}
 	case "scan":
-		return &ScanFormatter{Verbose: verbose}
+		return &ScanFormatter{Verbose: verbose, ShowMAC: showMAC}
 	default:
 		return &ColorFormatter{Verbose: verbose}
 	}
@@ -250,7 +250,9 @@ func (f *TableFormatter) Format(results []client.Result) error {
 }
 
 // SummaryTableFormatter formats summary results grouped by subnet
-type SummaryTableFormatter struct{}
+type SummaryTableFormatter struct {
+	ShowMAC bool
+}
 
 func (f *SummaryTableFormatter) Format(results []client.Result) error {
 	// Group results by subnet
@@ -289,8 +291,13 @@ func (f *SummaryTableFormatter) Format(results []client.Result) error {
 
 		// Print subnet header
 		fmt.Fprintf(w, "\n=== Subnet: %s ===\n", subnet)
-		fmt.Fprintln(w, "IP\tAccepted\tMHS 5s\tMHS av\tHardware Errors")
-		fmt.Fprintln(w, "---\t--------\t------\t------\t---------------")
+		if f.ShowMAC {
+			fmt.Fprintln(w, "IP\tMAC\tAccepted\tMHS 5s\tMHS av\tHardware Errors")
+			fmt.Fprintln(w, "---\t-----------------\t--------\t------\t------\t---------------")
+		} else {
+			fmt.Fprintln(w, "IP\tAccepted\tMHS 5s\tMHS av\tHardware Errors")
+			fmt.Fprintln(w, "---\t--------\t------\t------\t---------------")
+		}
 
 		// Sort IPs within subnet
 		sort.Slice(results, func(i, j int) bool {
@@ -303,6 +310,7 @@ func (f *SummaryTableFormatter) Format(results []client.Result) error {
 			mhs5s := "-"
 			mhsAv := "-"
 			hwErrors := "-"
+			macAddress := "-"
 
 			// Extract summary data from response
 			// The response might be a struct or a map depending on how it was processed
@@ -323,16 +331,30 @@ func (f *SummaryTableFormatter) Format(results []client.Result) error {
 					if val, ok := respMap["Hardware Errors"]; ok {
 						hwErrors = fmt.Sprintf("%v", val)
 					}
+					if val, ok := respMap["mac_address"]; ok {
+						macAddress = fmt.Sprintf("%v", val)
+					}
 				}
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				result.IP,
-				accepted,
-				mhs5s,
-				mhsAv,
-				hwErrors,
-			)
+			if f.ShowMAC {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					result.IP,
+					macAddress,
+					accepted,
+					mhs5s,
+					mhsAv,
+					hwErrors,
+				)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+					result.IP,
+					accepted,
+					mhs5s,
+					mhsAv,
+					hwErrors,
+				)
+			}
 		}
 	}
 
@@ -414,6 +436,7 @@ func toFloat64(v interface{}) float64 {
 // ScanFormatter displays scan results with miner details including hashrate
 type ScanFormatter struct {
 	Verbose bool
+	ShowMAC bool
 }
 
 // ansiRegex matches ANSI escape sequences for removing them when calculating display width
@@ -805,13 +828,27 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 	var headerColors []func(...interface{}) string
 	var separatorLine string
 
-	if hasPortData {
+	if hasPortData && f.ShowMAC {
+		headers = []string{"IP", "Port", "MAC", "Status", "Firmware", "Hashrate (GH/s)", "Power (kW)", "Temp (°C)", "Tuning", "Accepted", "Rejected", "HW Errors", "Uptime"}
+		headerColors = make([]func(...interface{}) string, len(headers))
+		for i := range headerColors {
+			headerColors[i] = headerColor
+		}
+		separatorLine = cyan("───  ────  ─────────────────  ───────  ────────  ───────────────  ──────────  ─────────  ──────  ────────  ────────  ─────────  ──────")
+	} else if hasPortData {
 		headers = []string{"IP", "Port", "Status", "Firmware", "Hashrate (GH/s)", "Power (kW)", "Temp (°C)", "Tuning", "Accepted", "Rejected", "HW Errors", "Uptime"}
 		headerColors = make([]func(...interface{}) string, len(headers))
 		for i := range headerColors {
 			headerColors[i] = headerColor
 		}
 		separatorLine = cyan("───  ────  ───────  ────────  ───────────────  ──────────  ─────────  ──────  ────────  ────────  ─────────  ──────")
+	} else if f.ShowMAC {
+		headers = []string{"IP", "MAC", "Status", "Firmware", "Hashrate (GH/s)", "Power (kW)", "Temp (°C)", "Tuning", "Accepted", "Rejected", "HW Errors", "Uptime"}
+		headerColors = make([]func(...interface{}) string, len(headers))
+		for i := range headerColors {
+			headerColors[i] = headerColor
+		}
+		separatorLine = cyan("───  ─────────────────  ───────  ────────  ───────────────  ──────────  ─────────  ──────  ────────  ────────  ─────────  ──────")
 	} else {
 		headers = []string{"IP", "Status", "Firmware", "Hashrate (GH/s)", "Power (kW)", "Temp (°C)", "Tuning", "Accepted", "Rejected", "HW Errors", "Uptime"}
 		headerColors = make([]func(...interface{}) string, len(headers))
@@ -829,7 +866,17 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		// But show miners with Disconnected errors (they're online but stopped)
 		if result.Error != "" && result.Response == nil {
 			if f.Verbose {
-				if hasPortData {
+				if hasPortData && f.ShowMAC {
+					rows = append(rows, tableRow{
+						plainValues:   []string{result.IP, "-", "-", "✗ Offline", "-", "offline", "-", "-", "-", "-", "-", "-", "-"},
+						coloredValues: []string{white(result.IP), white("-"), white("-"), red("✗ Offline"), white("-"), red("offline"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-")},
+					})
+				} else if hasPortData {
+					rows = append(rows, tableRow{
+						plainValues:   []string{result.IP, "-", "✗ Offline", "-", "offline", "-", "-", "-", "-", "-", "-", "-"},
+						coloredValues: []string{white(result.IP), white("-"), red("✗ Offline"), white("-"), red("offline"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-")},
+					})
+				} else if f.ShowMAC {
 					rows = append(rows, tableRow{
 						plainValues:   []string{result.IP, "-", "✗ Offline", "-", "offline", "-", "-", "-", "-", "-", "-", "-"},
 						coloredValues: []string{white(result.IP), white("-"), red("✗ Offline"), white("-"), red("offline"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-"), white("-")},
@@ -861,10 +908,20 @@ func (f *ScanFormatter) Format(results []client.Result) error {
 		}
 		ipColor, statusColor, statusDisplay, firmwareColor, hashrateColor, powerColor, tempColor, tuningDisplay, tuningColor, acceptedColor, rejectedColor, hwErrorsColor, uptimeColor := f.colorizeMinerData(data, result, colors)
 
-		if hasPortData {
+		if hasPortData && f.ShowMAC {
+			rows = append(rows, tableRow{
+				plainValues:   []string{result.IP, data.switchPort, data.macAddress, statusDisplay, data.firmware, data.hashrate, data.powerKW, data.chipTemp, tuningDisplay, data.accepted, data.rejected, data.hwErrors, data.uptime},
+				coloredValues: []string{ipColor, white(data.switchPort), cyan(data.macAddress), statusColor, firmwareColor, hashrateColor, powerColor, tempColor, tuningColor, acceptedColor, rejectedColor, hwErrorsColor, uptimeColor},
+			})
+		} else if hasPortData {
 			rows = append(rows, tableRow{
 				plainValues:   []string{result.IP, data.switchPort, statusDisplay, data.firmware, data.hashrate, data.powerKW, data.chipTemp, tuningDisplay, data.accepted, data.rejected, data.hwErrors, data.uptime},
 				coloredValues: []string{ipColor, white(data.switchPort), statusColor, firmwareColor, hashrateColor, powerColor, tempColor, tuningColor, acceptedColor, rejectedColor, hwErrorsColor, uptimeColor},
+			})
+		} else if f.ShowMAC {
+			rows = append(rows, tableRow{
+				plainValues:   []string{result.IP, data.macAddress, statusDisplay, data.firmware, data.hashrate, data.powerKW, data.chipTemp, tuningDisplay, data.accepted, data.rejected, data.hwErrors, data.uptime},
+				coloredValues: []string{ipColor, cyan(data.macAddress), statusColor, firmwareColor, hashrateColor, powerColor, tempColor, tuningColor, acceptedColor, rejectedColor, hwErrorsColor, uptimeColor},
 			})
 		} else {
 			rows = append(rows, tableRow{
@@ -906,6 +963,7 @@ type minerData struct {
 	minerStatus string
 	firmware    string
 	switchPort  string
+	macAddress  string
 	hashrate    string
 	powerKW     string
 	chipTemp    string
@@ -922,6 +980,7 @@ func (f *ScanFormatter) extractMinerData(result client.Result) minerData {
 		minerStatus: "-",
 		firmware:    "-",
 		switchPort:  "-",
+		macAddress:  "-",
 		hashrate:    "-",
 		powerKW:     "-",
 		chipTemp:    "-",
@@ -953,6 +1012,10 @@ func (f *ScanFormatter) extractMinerData(result client.Result) minerData {
 	// Get switch port info
 	if val, ok := respMap["switch_port"]; ok {
 		data.switchPort = fmt.Sprintf("%v", val)
+	}
+	// Get MAC address
+	if val, ok := respMap["mac_address"]; ok {
+		data.macAddress = fmt.Sprintf("%v", val)
 	}
 
 	// Get hashrate (prefer MHS 5s over MHS av, convert MH/s to GH/s)

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -84,7 +84,7 @@ func TestGetFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
-			formatter := GetFormatter(tt.format, tt.verbose)
+			formatter := GetFormatter(tt.format, tt.verbose, false)
 
 			switch tt.expected {
 			case "JSONFormatter":

--- a/internal/whatsminer/client.go
+++ b/internal/whatsminer/client.go
@@ -198,7 +198,10 @@ func (c *Client) send(message string) (*Response, error) {
 	}
 
 	// Clear deadlines after successful operation
-	c.conn.SetDeadline(time.Time{})
+	if err := c.conn.SetDeadline(time.Time{}); err != nil {
+		// Log but don't fail - deadline clearing is best effort
+		_ = err
+	}
 
 	// Parse JSON response
 	var response Response
@@ -254,7 +257,7 @@ func (c *Client) GetDeviceInfo() (*Response, error) {
 
 	// Auto-set salt if available
 	if resp.Code == 0 {
-		if msg, err := resp.GetMsg(); err == nil {
+		if msg, msgErr := resp.GetMsg(); msgErr == nil {
 			if salt, ok := msg["salt"].(string); ok {
 				c.SetSalt(salt)
 			}

--- a/internal/whatsminer/client.go
+++ b/internal/whatsminer/client.go
@@ -1,0 +1,284 @@
+package whatsminer
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Client represents a WhatsMiner API v3 client
+type Client struct {
+	ip       string
+	port     int
+	account  string
+	password string
+	salt     string
+	conn     net.Conn
+	timeout  time.Duration
+}
+
+// Response represents the standard API response structure
+type Response struct {
+	Code int             `json:"code"`
+	Msg  json.RawMessage `json:"msg"` // Can be object or string
+	When int64           `json:"when,omitempty"`
+	Desc string          `json:"desc,omitempty"`
+}
+
+// GetMsg returns the msg field as a map (when code is 0)
+func (r *Response) GetMsg() (map[string]interface{}, error) {
+	var msg map[string]interface{}
+	if err := json.Unmarshal(r.Msg, &msg); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+// GetMsgString returns the msg field as a string (typically when code != 0)
+func (r *Response) GetMsgString() (string, error) {
+	var msg string
+	if err := json.Unmarshal(r.Msg, &msg); err != nil {
+		return "", err
+	}
+	return msg, nil
+}
+
+// IsSuccess checks if the response code indicates success
+func (r *Response) IsSuccess() bool {
+	return r.Code == 0
+}
+
+// GetMessage retrieves a specific message field as a string
+func (r *Response) GetMessage(key string) (string, bool) {
+	msg, err := r.GetMsg()
+	if err != nil {
+		return "", false
+	}
+	if val, ok := msg[key]; ok {
+		if str, ok := val.(string); ok {
+			return str, true
+		}
+	}
+	return "", false
+}
+
+// GetFloat retrieves a specific message field as a float64
+func (r *Response) GetFloat(key string) (float64, bool) {
+	msg, err := r.GetMsg()
+	if err != nil {
+		return 0, false
+	}
+	if val, ok := msg[key]; ok {
+		if f, ok := val.(float64); ok {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+// GetInt retrieves a specific message field as an int
+func (r *Response) GetInt(key string) (int, bool) {
+	msg, err := r.GetMsg()
+	if err != nil {
+		return 0, false
+	}
+	if val, ok := msg[key]; ok {
+		if f, ok := val.(float64); ok {
+			return int(f), true
+		}
+		if i, ok := val.(int); ok {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// NewClient creates a new WhatsMiner API client
+func NewClient(ip string, port int, account, password string, timeout time.Duration) *Client {
+	return &Client{
+		ip:       ip,
+		port:     port,
+		account:  account,
+		password: password,
+		timeout:  timeout,
+	}
+}
+
+// Connect establishes a TCP connection to the miner
+func (c *Client) Connect() error {
+	address := net.JoinHostPort(c.ip, fmt.Sprintf("%d", c.port))
+	conn, err := net.DialTimeout("tcp", address, c.timeout)
+	if err != nil {
+		return fmt.Errorf("failed to connect to %s: %w", address, err)
+	}
+	c.conn = conn
+	return nil
+}
+
+// Close closes the TCP connection
+func (c *Client) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}
+
+// SetSalt sets the salt value for authentication (retrieved from get.device.info)
+func (c *Client) SetSalt(salt string) {
+	c.salt = salt
+}
+
+// generateToken generates an authentication token
+// Token = first 8 characters of Base64(SHA256(command + password + salt + timestamp))
+func (c *Client) generateToken(command string, ts int64) string {
+	srcBuff := fmt.Sprintf("%s%s%s%d", command, c.password, c.salt, ts)
+	hash := sha256.Sum256([]byte(srcBuff))
+	encoded := base64.StdEncoding.EncodeToString(hash[:])
+	return encoded[:8]
+}
+
+// send sends a message to the miner and receives the response
+func (c *Client) send(message string) (*Response, error) {
+	if c.conn == nil {
+		return nil, fmt.Errorf("not connected")
+	}
+
+	// Set write deadline
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+		return nil, fmt.Errorf("failed to set write deadline: %w", err)
+	}
+
+	// Send message length (4 bytes, little-endian)
+	messageLen := len(message)
+	if messageLen > 0x7FFFFFFF { // Max int32 to prevent overflow
+		return nil, fmt.Errorf("message too large: %d bytes", messageLen)
+	}
+	length := uint32(messageLen)
+	lengthBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lengthBytes, length)
+
+	if _, err := c.conn.Write(lengthBytes); err != nil {
+		return nil, fmt.Errorf("failed to send message length: %w", err)
+	}
+
+	// Send message
+	if _, err := c.conn.Write([]byte(message)); err != nil {
+		return nil, fmt.Errorf("failed to send message: %w", err)
+	}
+
+	// Set read deadline
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.timeout * 2)); err != nil {
+		return nil, fmt.Errorf("failed to set read deadline: %w", err)
+	}
+
+	// Receive response length (4 bytes, little-endian)
+	lengthBytes = make([]byte, 4)
+	if _, err := c.conn.Read(lengthBytes); err != nil {
+		return nil, fmt.Errorf("failed to receive response length: %w", err)
+	}
+	responseLen := binary.LittleEndian.Uint32(lengthBytes)
+
+	if responseLen > 1024*1024 { // 1MB max response size
+		return nil, fmt.Errorf("invalid response length: %d", responseLen)
+	}
+
+	// Receive response data
+	buffer := make([]byte, responseLen)
+	totalRead := 0
+	for totalRead < int(responseLen) {
+		n, err := c.conn.Read(buffer[totalRead:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive response data: %w", err)
+		}
+		totalRead += n
+	}
+
+	// Clear deadlines after successful operation
+	c.conn.SetDeadline(time.Time{})
+
+	// Parse JSON response
+	var response Response
+	if err := json.Unmarshal(buffer, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// GetRequest sends a GET command (no authentication required)
+func (c *Client) GetRequest(cmd string, param interface{}) (*Response, error) {
+	payload := map[string]interface{}{
+		"cmd":   cmd,
+		"param": param,
+	}
+
+	message, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	return c.send(string(message))
+}
+
+// SetRequest sends a SET command (requires authentication)
+func (c *Client) SetRequest(cmd string, param interface{}) (*Response, error) {
+	ts := time.Now().Unix()
+	token := c.generateToken(cmd, ts)
+
+	payload := map[string]interface{}{
+		"cmd":     cmd,
+		"param":   param,
+		"ts":      ts,
+		"token":   token,
+		"account": c.account,
+	}
+
+	message, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	return c.send(string(message))
+}
+
+// GetDeviceInfo retrieves device information and salt
+func (c *Client) GetDeviceInfo() (*Response, error) {
+	resp, err := c.GetRequest("get.device.info", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Auto-set salt if available
+	if resp.Code == 0 {
+		if msg, err := resp.GetMsg(); err == nil {
+			if salt, ok := msg["salt"].(string); ok {
+				c.SetSalt(salt)
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+// GetMinerStatus retrieves real-time miner status with detailed metrics
+func (c *Client) GetMinerStatus(param string) (*Response, error) {
+	return c.GetRequest("get.miner.status", param)
+}
+
+// SetMinerService starts or stops the mining service
+func (c *Client) SetMinerService(param string) (*Response, error) {
+	return c.SetRequest("set.miner.service", param)
+}
+
+// SetMinerPowerPercent sets the miner power as a percentage of maximum
+func (c *Client) SetMinerPowerPercent(mode, percent string) (*Response, error) {
+	param := map[string]string{
+		"percent": percent,
+		"mode":    mode,
+	}
+	return c.SetRequest("set.miner.power_percent", param)
+}

--- a/internal/whatsminer/helpers.go
+++ b/internal/whatsminer/helpers.go
@@ -1,0 +1,150 @@
+package whatsminer
+
+import (
+	"fmt"
+	"time"
+)
+
+// MinerStats represents common miner statistics
+type MinerStats struct {
+	Hashrate   float64 // TH/s
+	Power      float64 // Watts
+	Temp       float64 // Celsius (average chip temp)
+	TempBoards []float64 // Per-board temperatures
+	Working    bool    // Is miner actively mining
+	Model      string  // Miner model (e.g., "M30S++")
+}
+
+// GetMinerStats retrieves and parses common miner statistics
+func (c *Client) GetMinerStats() (*MinerStats, error) {
+	resp, err := c.GetMinerStatus("summary")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		// Try to get error message
+		if msgStr, msgErr := resp.GetMsgString(); msgErr == nil {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, msgStr)
+		}
+		return nil, fmt.Errorf("API error code: %d", resp.Code)
+	}
+
+	msg, err := resp.GetMsg()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response message: %w", err)
+	}
+
+	stats := &MinerStats{}
+
+	// Extract hashrate (in TH/s)
+	if hashrate, ok := msg["hash-realtime"].(float64); ok {
+		stats.Hashrate = hashrate
+	}
+
+	// Extract power (in Watts)
+	if power, ok := msg["power-realtime"].(float64); ok {
+		stats.Power = power
+	}
+
+	// Extract temperature (average chip temp)
+	if temp, ok := msg["chip-temp-avg"].(float64); ok {
+		stats.Temp = temp
+	}
+
+	// Extract per-board temperatures
+	if boards, ok := msg["boards"].([]interface{}); ok {
+		for _, board := range boards {
+			if boardMap, ok := board.(map[string]interface{}); ok {
+				if temp, ok := boardMap["chip-temp-avg"].(float64); ok {
+					stats.TempBoards = append(stats.TempBoards, temp)
+				}
+			}
+		}
+	}
+
+	// Extract working status
+	if working, ok := msg["working"].(string); ok {
+		stats.Working = working == "true"
+	} else if working, ok := msg["working"].(bool); ok {
+		stats.Working = working
+	}
+
+	// Extract model
+	if model, ok := msg["type"].(string); ok {
+		stats.Model = model
+	}
+
+	return stats, nil
+}
+
+// IsWhatsMiner checks if a device at the given IP is a WhatsMiner
+// Returns true if it successfully connects to the WhatsMiner API
+func IsWhatsMiner(ip string, port int, timeout time.Duration) bool {
+	client := NewClient(ip, port, "super", "super", timeout)
+	if err := client.Connect(); err != nil {
+		return false
+	}
+	defer client.Close()
+
+	// Try to get device info - this is a reliable way to detect WhatsMiner
+	resp, err := client.GetDeviceInfo()
+	if err != nil {
+		return false
+	}
+
+	// Check if response is valid WhatsMiner format
+	return resp.Code == 0 || resp.Code < 0 // Valid response codes
+}
+
+// GetFirmwareVersion retrieves the firmware version string
+func (c *Client) GetFirmwareVersion() (string, error) {
+	resp, err := c.GetDeviceInfo()
+	if err != nil {
+		return "", err
+	}
+
+	if !resp.IsSuccess() {
+		return "", fmt.Errorf("failed to get device info")
+	}
+
+	msg, err := resp.GetMsg()
+	if err != nil {
+		return "", err
+	}
+
+	// Try to get version from system info
+	if system, ok := msg["system"].(map[string]interface{}); ok {
+		if version, ok := system["software_version"].(string); ok {
+			return version, nil
+		}
+	}
+
+	return "Unknown", nil
+}
+
+// GetMinerModel retrieves the miner model string
+func (c *Client) GetMinerModel() (string, error) {
+	resp, err := c.GetDeviceInfo()
+	if err != nil {
+		return "", err
+	}
+
+	if !resp.IsSuccess() {
+		return "", fmt.Errorf("failed to get device info")
+	}
+
+	msg, err := resp.GetMsg()
+	if err != nil {
+		return "", err
+	}
+
+	// Try to get model from miner info
+	if miner, ok := msg["miner"].(map[string]interface{}); ok {
+		if model, ok := miner["type"].(string); ok {
+			return model, nil
+		}
+	}
+
+	return "WhatsMiner", nil
+}

--- a/internal/whatsminer/helpers.go
+++ b/internal/whatsminer/helpers.go
@@ -152,3 +152,45 @@ func (c *Client) GetMinerModel() (string, error) {
 
 	return "WhatsMiner", nil
 }
+
+// ErrorCodeInfo represents a WhatsMiner error code entry
+type ErrorCodeInfo struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"msg"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// GetErrorCodes retrieves error codes from the device info response
+func GetErrorCodesFromDeviceInfo(deviceInfo *Response) []ErrorCodeInfo {
+	var errorCodes []ErrorCodeInfo
+
+	msg, err := deviceInfo.GetMsg()
+	if err != nil {
+		return errorCodes
+	}
+
+	// Error codes are in the "error-code" field
+	if errorCodesRaw, ok := msg["error-code"]; ok {
+		if errorCodesArray, ok := errorCodesRaw.([]interface{}); ok {
+			for _, errItem := range errorCodesArray {
+				if errMap, ok := errItem.(map[string]interface{}); ok {
+					errorCode := ErrorCodeInfo{}
+
+					if code, ok := errMap["error_code"].(string); ok {
+						errorCode.ErrorCode = code
+					}
+					if message, ok := errMap["msg"].(string); ok {
+						errorCode.Message = message
+					}
+					if ts, ok := errMap["timestamp"].(float64); ok {
+						errorCode.Timestamp = int64(ts)
+					}
+
+					errorCodes = append(errorCodes, errorCode)
+				}
+			}
+		}
+	}
+
+	return errorCodes
+}

--- a/internal/whatsminer/helpers.go
+++ b/internal/whatsminer/helpers.go
@@ -37,43 +37,47 @@ func (c *Client) GetMinerStats() (*MinerStats, error) {
 
 	stats := &MinerStats{}
 
+	// The response has a "summary" object inside msg
+	var summary map[string]interface{}
+	if summaryObj, ok := msg["summary"].(map[string]interface{}); ok {
+		summary = summaryObj
+	} else {
+		// Fallback to top-level msg if no summary object
+		summary = msg
+	}
+
 	// Extract hashrate (in TH/s)
-	if hashrate, ok := msg["hash-realtime"].(float64); ok {
+	if hashrate, ok := summary["hash-realtime"].(float64); ok {
 		stats.Hashrate = hashrate
 	}
 
 	// Extract power (in Watts)
-	if power, ok := msg["power-realtime"].(float64); ok {
+	if power, ok := summary["power-realtime"].(float64); ok {
 		stats.Power = power
+	} else if power, ok := summary["power-realtime"].(int); ok {
+		stats.Power = float64(power)
 	}
 
 	// Extract temperature (average chip temp)
-	if temp, ok := msg["chip-temp-avg"].(float64); ok {
+	if temp, ok := summary["chip-temp-avg"].(float64); ok {
 		stats.Temp = temp
 	}
 
 	// Extract per-board temperatures
-	if boards, ok := msg["boards"].([]interface{}); ok {
-		for _, board := range boards {
-			if boardMap, ok := board.(map[string]interface{}); ok {
-				if temp, ok := boardMap["chip-temp-avg"].(float64); ok {
-					stats.TempBoards = append(stats.TempBoards, temp)
-				}
+	if boardTemps, ok := summary["board-temperature"].([]interface{}); ok {
+		for _, temp := range boardTemps {
+			if tempFloat, ok := temp.(float64); ok {
+				stats.TempBoards = append(stats.TempBoards, tempFloat)
 			}
 		}
 	}
 
-	// Extract working status
-	if working, ok := msg["working"].(string); ok {
-		stats.Working = working == "true"
-	} else if working, ok := msg["working"].(bool); ok {
-		stats.Working = working
-	}
+	// Determine working status - if hashrate > 0, it's working
+	stats.Working = stats.Hashrate > 0
 
-	// Extract model
-	if model, ok := msg["type"].(string); ok {
-		stats.Model = model
-	}
+	// Extract model from device info (need separate call)
+	// For now, leave empty - will be populated from device info call
+	stats.Model = ""
 
 	return stats, nil
 }

--- a/internal/whatsminer/helpers.go
+++ b/internal/whatsminer/helpers.go
@@ -170,23 +170,39 @@ func GetErrorCodesFromDeviceInfo(deviceInfo *Response) []ErrorCodeInfo {
 	}
 
 	// Error codes are in the "error-code" field
+	// Format: [{"530": "1970-01-01 08:00:26", "reason": "Slot0 not found."}, ...]
 	if errorCodesRaw, ok := msg["error-code"]; ok {
 		if errorCodesArray, ok := errorCodesRaw.([]interface{}); ok {
 			for _, errItem := range errorCodesArray {
 				if errMap, ok := errItem.(map[string]interface{}); ok {
 					errorCode := ErrorCodeInfo{}
 
-					if code, ok := errMap["error_code"].(string); ok {
-						errorCode.ErrorCode = code
-					}
-					if message, ok := errMap["msg"].(string); ok {
-						errorCode.Message = message
-					}
-					if ts, ok := errMap["timestamp"].(float64); ok {
-						errorCode.Timestamp = int64(ts)
+					// Extract the reason/message
+					if reason, ok := errMap["reason"].(string); ok {
+						errorCode.Message = reason
 					}
 
-					errorCodes = append(errorCodes, errorCode)
+					// The error code is a key in the map (not "error_code")
+					// Find the numeric key (e.g., "530", "531")
+					for key, val := range errMap {
+						if key == "reason" {
+							continue
+						}
+						// This is the error code
+						errorCode.ErrorCode = key
+
+						// The value is a timestamp string like "1970-01-01 08:00:26"
+						if tsStr, ok := val.(string); ok {
+							// Parse the timestamp string
+							if t, err := time.Parse("2006-01-02 15:04:05", tsStr); err == nil {
+								errorCode.Timestamp = t.Unix()
+							}
+						}
+					}
+
+					if errorCode.ErrorCode != "" {
+						errorCodes = append(errorCodes, errorCode)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Add WhatsMiner API v3 integration with full support for WhatsMiner devices
- Add error code detection and reporting with `--check-errors` flag
- Add MAC address retrieval and display with `--show-mac` flag
- Add concurrent enrichment for improved network scanning performance
- Fix stats parsing and error code handling for active WhatsMiner devices
- Improve output formatting for scan results

## Key Features
1. **WhatsMiner API Integration**: Native support for WhatsMiner devices alongside existing CGMiner support
2. **Error Code Detection**: New `--check-errors` flag to detect and display WhatsMiner error codes during scanning
3. **MAC Address Display**: New `--show-mac` flag to include MAC addresses in scan output tables
4. **Performance Improvements**: Concurrent enrichment for faster network scans
5. **Enhanced Output**: Cleaner scan formatting with better data presentation

## Test plan
- [ ] Test scanning WhatsMiner devices with the new API integration
- [ ] Verify `--check-errors` flag correctly detects and displays error codes
- [ ] Verify `--show-mac` flag displays MAC addresses in output tables
- [ ] Test concurrent scanning performance with multiple devices
- [ ] Verify backward compatibility with existing CGMiner functionality
- [ ] Run existing test suite to ensure no regressions